### PR TITLE
Have Entry::symlink() return Option<&str>

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -101,6 +101,7 @@ pub enum FileType {
     NamedPipe,
     Mount,
     RegularFile,
+    Unknown,
 }
 
 pub trait Handle {
@@ -134,6 +135,7 @@ pub trait Entry {
                 ffi::AE_IFMT => FileType::Mount,
                 ffi::AE_IFREG => FileType::RegularFile,
                 ffi::AE_IFSOCK => FileType::Socket,
+                0 => FileType::Unknown,
                 code => unreachable!("undefined filetype: {}", code),
             }
         }
@@ -184,6 +186,7 @@ pub trait Entry {
                 FileType::Mount => ffi::AE_IFMT,
                 FileType::RegularFile => ffi::AE_IFREG,
                 FileType::Socket => ffi::AE_IFSOCK,
+                FileType::Unknown => 0,
             };
             ffi::archive_entry_set_filetype(self.entry(), file_type);
         }

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -161,10 +161,16 @@ pub trait Entry {
         unsafe { ffi::archive_entry_size(self.entry()) }
     }
 
-    fn symlink(&self) -> &str {
-        let c_str: &CStr = unsafe { CStr::from_ptr(ffi::archive_entry_symlink(self.entry())) };
+    fn symlink(&self) -> Option<&str> {
+        let c_str: &CStr = unsafe {
+            let ptr = ffi::archive_entry_symlink(self.entry());
+            if ptr.is_null() {
+                return None;
+            }
+            CStr::from_ptr(ptr)
+        };
         let buf: &[u8] = c_str.to_bytes();
-        str::from_utf8(buf).unwrap()
+        Some(str::from_utf8(buf).unwrap())
     }
 
     fn set_filetype(&mut self, file_type: FileType) {


### PR DESCRIPTION
`archive_entry_symlink()` returns NULL if the entry is not a symlink. Calling Entry::symlink() would result in a segfault in that case.

This PR introduces API breakage by changing the return type; A less breaking solution is to have the method panic on NULL, but that'd be inconsistent with other methods such as Entry::hardlink().
