### PR TITLE
Add Unknown value to Entry::FileType

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -101,6 +101,7 @@ pub enum FileType {
     NamedPipe,
     Mount,
     RegularFile,
+    Unknown,
 }
 
 pub trait Handle {
@@ -134,6 +135,7 @@ pub trait Entry {
                 ffi::AE_IFMT => FileType::Mount,
                 ffi::AE_IFREG => FileType::RegularFile,
                 ffi::AE_IFSOCK => FileType::Socket,
+                0 => FileType::Unknown,
                 code => unreachable!("undefined filetype: {}", code),
             }
         }
@@ -178,6 +180,7 @@ pub trait Entry {
                 FileType::Mount => ffi::AE_IFMT,
                 FileType::RegularFile => ffi::AE_IFREG,
                 FileType::Socket => ffi::AE_IFSOCK,
+                FileType::Unknown => 0,
             };
             ffi::archive_entry_set_filetype(self.entry(), file_type);
         }


### PR DESCRIPTION
To handle the case where archive_entry_filetype() returns 0, which it does in the case of hardlinks in a tar archive.

From reading the libarchive source, it seems that archive_entry_set_filetype() also accepts 0; so this type, while undocumented, seems to be supported.
