### PR TITLE
Use automatic generated bindings from fnichol/libarchive3-sys#6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ description = "A safe Rust API for authoring and extracting archives with libarc
 keywords = ["libarchive", "archive", "tar", "zip"]
 
 [dependencies]
-libc = ">= 0.2.0"
-libarchive3-sys = "0.1"
+libc = "0.2.147"
+libarchive3-sys = { git = "https://github.com/jerry73204/libarchive3-sys.git", branch = "rewrite-using-bindgen" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "libarchive"
 version = "0.1.1"
+edition = "2021"
 authors = ["Jamie Winsor <reset@chef.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/chef/libarchive-rust"

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::str;
 
 use crate::error::ErrCode;
-use libarchive3_sys::ffi;
+use libarchive3_sys as ffi;
 
 pub enum ReadCompression {
     All,
@@ -104,7 +104,7 @@ pub enum FileType {
 }
 
 pub trait Handle {
-    unsafe fn handle(&self) -> *mut ffi::Struct_archive;
+    unsafe fn handle(&self) -> *mut ffi::archive;
 
     fn err_code(&self) -> ErrCode {
         let code = unsafe { ffi::archive_errno(self.handle()) };
@@ -121,7 +121,7 @@ pub trait Handle {
 }
 
 pub trait Entry {
-    unsafe fn entry(&self) -> *mut ffi::Struct_archive_entry;
+    unsafe fn entry(&self) -> *mut ffi::archive_entry;
 
     fn filetype(&self) -> FileType {
         unsafe {

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -3,8 +3,8 @@ use std::ffi::{CStr, CString};
 use std::path::PathBuf;
 use std::str;
 
+use crate::error::ErrCode;
 use libarchive3_sys::ffi;
-use error::ErrCode;
 
 pub enum ReadCompression {
     All,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
+use crate::archive;
 use std::error;
 use std::fmt;
-use archive;
 
 pub type ArchiveResult<T> = Result<T, ArchiveError>;
 
@@ -42,14 +42,14 @@ impl fmt::Display for ArchiveError {
     }
 }
 
-impl<'a> From<&'a archive::Handle> for ArchiveError {
-    fn from(handle: &'a archive::Handle) -> ArchiveError {
+impl<'a> From<&'a dyn archive::Handle> for ArchiveError {
+    fn from(handle: &'a dyn archive::Handle) -> ArchiveError {
         ArchiveError::Sys(handle.err_code(), handle.err_msg())
     }
 }
 
-impl<'a> From<&'a archive::Handle> for ArchiveResult<()> {
-    fn from(handle: &'a archive::Handle) -> ArchiveResult<()> {
+impl<'a> From<&'a dyn archive::Handle> for ArchiveResult<()> {
+    fn from(handle: &'a dyn archive::Handle) -> ArchiveResult<()> {
         match handle.err_code() {
             ErrCode(0) => Ok(()),
             _ => Err(ArchiveError::from(handle)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate libc;
-extern crate libarchive3_sys;
-
 pub mod archive;
 pub mod error;
 pub mod reader;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::ptr;
 use std::slice;
 
-use libarchive3_sys::ffi;
+use libarchive3_sys as ffi;
 use libc::{c_void, ssize_t};
 
 use crate::archive::{Entry, Handle, ReadCompression, ReadFilter, ReadFormat};
@@ -16,7 +16,7 @@ use crate::error::{ArchiveError, ArchiveResult};
 const BLOCK_SIZE: usize = 10240;
 
 unsafe extern "C" fn stream_read_callback(
-    handle: *mut ffi::Struct_archive,
+    handle: *mut ffi::archive,
     data: *mut c_void,
     buff: *mut *const c_void,
 ) -> ssize_t {
@@ -64,23 +64,23 @@ pub trait Reader: Handle {
 }
 
 pub struct FileReader {
-    handle: *mut ffi::Struct_archive,
+    handle: *mut ffi::archive,
     entry: ReaderEntry,
 }
 
 pub struct StreamReader {
-    handle: *mut ffi::Struct_archive,
+    handle: *mut ffi::archive,
     entry: ReaderEntry,
     _pipe: Box<Pipe>,
 }
 
 pub struct Builder {
-    handle: *mut ffi::Struct_archive,
+    handle: *mut ffi::archive,
     consumed: bool,
 }
 
 pub struct ReaderEntry {
-    handle: *mut ffi::Struct_archive_entry,
+    handle: *mut ffi::archive_entry,
 }
 
 struct Pipe {
@@ -116,7 +116,7 @@ impl FileReader {
         }
     }
 
-    fn new(handle: *mut ffi::Struct_archive) -> Self {
+    fn new(handle: *mut ffi::archive) -> Self {
         FileReader {
             handle: handle,
             entry: ReaderEntry::default(),
@@ -125,7 +125,7 @@ impl FileReader {
 }
 
 impl Handle for FileReader {
-    unsafe fn handle(&self) -> *mut ffi::Struct_archive {
+    unsafe fn handle(&self) -> *mut ffi::archive {
         self.handle
     }
 }
@@ -175,7 +175,7 @@ impl StreamReader {
 }
 
 impl Handle for StreamReader {
-    unsafe fn handle(&self) -> *mut ffi::Struct_archive {
+    unsafe fn handle(&self) -> *mut ffi::archive {
         self.handle
     }
 }
@@ -329,7 +329,7 @@ impl Builder {
 }
 
 impl Handle for Builder {
-    unsafe fn handle(&self) -> *mut ffi::Struct_archive {
+    unsafe fn handle(&self) -> *mut ffi::archive {
         self.handle
     }
 }
@@ -360,7 +360,7 @@ impl Default for Builder {
 }
 
 impl ReaderEntry {
-    pub fn new(handle: *mut ffi::Struct_archive_entry) -> Self {
+    pub fn new(handle: *mut ffi::archive_entry) -> Self {
         ReaderEntry { handle: handle }
     }
 }
@@ -374,7 +374,7 @@ impl Default for ReaderEntry {
 }
 
 impl Entry for ReaderEntry {
-    unsafe fn entry(&self) -> *mut ffi::Struct_archive_entry {
+    unsafe fn entry(&self) -> *mut ffi::archive_entry {
         self.handle
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -3,33 +3,33 @@ use std::ffi::CString;
 use std::path::Path;
 use std::ptr;
 
-use libarchive3_sys::ffi;
+use libarchive3_sys as ffi;
 
 use crate::archive::{Entry, ExtractOptions, Handle, WriteFilter, WriteFormat};
 use crate::error::{ArchiveError, ArchiveResult};
 use crate::reader::{Reader, ReaderEntry};
 
 pub struct Writer {
-    handle: *mut ffi::Struct_archive,
+    handle: *mut ffi::archive,
 }
 
 pub struct Disk {
-    handle: *mut ffi::Struct_archive,
+    handle: *mut ffi::archive,
 }
 
 pub struct Builder {
-    handle: *mut ffi::Struct_archive,
+    handle: *mut ffi::archive,
     consumed: bool,
 }
 
 impl Writer {
-    pub fn new(handle: *mut ffi::Struct_archive) -> Self {
+    pub fn new(handle: *mut ffi::archive) -> Self {
         Writer { handle: handle }
     }
 }
 
 impl Handle for Writer {
-    unsafe fn handle(&self) -> *mut ffi::Struct_archive {
+    unsafe fn handle(&self) -> *mut ffi::archive {
         self.handle
     }
 }
@@ -190,7 +190,7 @@ impl Disk {
 }
 
 impl Handle for Disk {
-    unsafe fn handle(&self) -> *mut ffi::Struct_archive {
+    unsafe fn handle(&self) -> *mut ffi::archive {
         self.handle
     }
 }
@@ -313,7 +313,7 @@ impl Default for Builder {
 }
 
 impl Handle for Builder {
-    unsafe fn handle(&self) -> *mut ffi::Struct_archive {
+    unsafe fn handle(&self) -> *mut ffi::archive {
         self.handle
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,10 +2,10 @@ extern crate libarchive;
 
 pub mod util;
 
-use std::fs::File;
 use libarchive::archive::{self, ReadFilter, ReadFormat};
 use libarchive::reader::{self, Reader};
 use libarchive::writer;
+use std::fs::File;
 
 #[test]
 fn reading_from_file() {
@@ -37,11 +37,14 @@ fn read_archive_from_stream() {
         Ok(mut reader) => {
             assert_eq!(reader.header_position(), 0);
             let writer = writer::Disk::new();
-            let count = writer.write(&mut reader, Some("/opt/bldr/fucks")).ok().unwrap();
+            let count = writer
+                .write(&mut reader, Some("/opt/bldr/fucks"))
+                .ok()
+                .unwrap();
             assert_eq!(count, 14);
             assert_eq!(reader.header_position(), 1024);
             assert_eq!(4, 4);
-        },
+        }
         Err(e) => {
             println!("{:?}", e);
         }
@@ -92,7 +95,7 @@ fn extracting_a_reader_twice() {
     println!("{:?}", reader.header_position());
     match writer.write(&mut reader, None) {
         Ok(_) => println!("oops"),
-        Err(_) => println!("nice")
+        Err(_) => println!("nice"),
     }
     assert_eq!(4, 4)
 }

--- a/tests/util/path.rs
+++ b/tests/util/path.rs
@@ -6,7 +6,14 @@ pub fn exe_path() -> PathBuf {
 }
 
 pub fn root() -> PathBuf {
-    exe_path().parent().unwrap().parent().unwrap().parent().unwrap().join("tests")
+    exe_path()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests")
 }
 
 pub fn fixtures() -> PathBuf {


### PR DESCRIPTION
This PR rewrites the code to automatically generate bindings using the modified libarchive3-sys crate fnichol/libarchive3-sys#6. The crate link in `Cargo.toml` points to GitHub for now. It will be modified as soon as the related PR is accepted and is published to crates.io.